### PR TITLE
Update the package version easy-grid to fix RN56

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "d3-ease": "^1.0.3",
     "lodash": "^4.17.5",
     "react-move": "^2.7.0",
-    "react-native-easy-grid": "^0.1.17",
+    "react-native-easy-grid": "^0.2.0",
     "react-native-keychain": "^3.0.0-rc.3",
     "react-native-touch-id": "^4.0.4",
     "react-native-vector-icons": "^4.5.0"


### PR DESCRIPTION
The old version 0.1.17 of the package "react-native-easy-grid" doesn't work with React Native 56. A rule of semver in your paclahge.json doesn't allow to install the package version as "0.2.0". Please update it