### PR TITLE
Lock react-native-keychain dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lodash": "^4.17.5",
     "react-move": "^2.7.0",
     "react-native-easy-grid": "^0.2.0",
-    "react-native-keychain": "^3.0.0-rc.3",
+    "react-native-keychain": "3.0.0",
     "react-native-touch-id": "^4.4.1",
     "react-native-vector-icons": "^4.5.0"
   },


### PR DESCRIPTION
Based on #66, I suggest locking `react-native-keychain` version to `3.0.0` since the bug was introduced on `3.1.0`