### PR TITLE
fix: #192: title centered

### DIFF
--- a/dist/src/PinCode.js
+++ b/dist/src/PinCode.js
@@ -537,7 +537,8 @@ const styles = react_native_1.StyleSheet.create({
     textTitle: {
         fontSize: 20,
         fontWeight: "200",
-        lineHeight: grid_1.grid.unit * 2.5
+        lineHeight: grid_1.grid.unit * 2.5,
+        textAlign: 'center'
     },
     textSubtitle: {
         fontSize: grid_1.grid.unit,

--- a/src/PinCode.tsx
+++ b/src/PinCode.tsx
@@ -849,7 +849,8 @@ const styles = StyleSheet.create({
   textTitle: {
     fontSize: 20,
     fontWeight: "200",
-    lineHeight: grid.unit * 2.5
+    lineHeight: grid.unit * 2.5,
+    textAlign: 'center'
   },
   textSubtitle: {
     fontSize: grid.unit,


### PR DESCRIPTION
https://github.com/jarden-digital/react-native-pincode/issues/192